### PR TITLE
Add PyInstaller build helper for Windows executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,105 @@
 # vils
+
+이 저장소에는 TOSUN CAN USB 장치로부터 CAN 프레임을 수집하고 필요한 정보를
+UDP로 전송하기 위한 간단한 Python 브리지 스크립트가 포함되어 있습니다.
+
+## 요구 사항
+
+- Python 3.9 이상
+- [python-can](https://python-can.readthedocs.io/) 패키지
+
+```bash
+pip install python-can
+```
+
+## 구성
+
+`config/example_config.json` 파일을 복사하여 환경에 맞도록 수정합니다.
+
+```bash
+cp config/example_config.json config/my_setup.json
+```
+
+구성 파일의 주요 항목은 다음과 같습니다.
+
+- `can`: python-can에서 사용하는 인터페이스 정보입니다. TOSUN CAN USB가
+  SocketCAN을 제공한다면 `interface`는 `"socketcan"`, `channel`은 `"can0"`처럼
+  설정합니다. 다른 드라이버(`"pcan"`, `"usb2can"` 등)를 사용할 경우 해당 드라이버에
+  맞게 값을 조정하십시오.
+- `udp`: 수신할 호스트와 포트 번호입니다.
+- `signals`: 특정 CAN ID에서 추출할 신호 정의 목록입니다. 각 신호는 다음 필드를
+  가집니다.
+  - `name`: UDP로 전송할 때 사용될 신호 이름
+  - `can_id`: 프레임의 식별자. 16진수 문자열(`"0x100"`) 또는 정수로 지정할 수 있습니다.
+  - `start_bit`: 추출할 비트의 시작 위치
+  - `length`: 추출할 비트 길이
+  - `byte_order`: `"little"`(기본값) 또는 `"big"`
+  - `signed`: 부호가 있는 값인지 여부 (기본값 `false`)
+  - `scale`, `offset`: 실제 물리 값을 계산하기 위한 선형 변환 계수
+- `include_raw_frame`: `true`로 설정하면 원본 프레임 데이터를 16진수 문자열로 함께 전송합니다.
+
+필요한 신호가 없다면 `signals` 배열을 비워 두어도 됩니다. 이 경우 해당 CAN ID는
+UDP로 전달되지 않습니다.
+
+## 실행 방법
+
+```bash
+python -m src.can_udp_bridge --config config/my_setup.json --log-level INFO
+```
+
+스크립트는 지정된 CAN 인터페이스에서 프레임을 수신하고 설정된 신호를
+추출하여 JSON 형태로 UDP 패킷에 담아 전송합니다. 전송되는 예시는 다음과 같습니다.
+
+```json
+{
+  "timestamp": 1709875306.123,
+  "can_id": 256,
+  "extended": false,
+  "signals": {
+    "vehicle_speed": 12.34
+  },
+  "raw_data": "1122334455667788"
+}
+```
+
+## 참고 사항
+
+- 실환경에서는 TOSUN CAN USB 드라이버가 OS에 제대로 설치되어 있고 python-can에서
+  해당 인터페이스를 인식할 수 있어야 합니다.
+- UDP 수신 측에서는 JSON 메시지를 파싱하여 필요한 정보를 추출할 수 있습니다.
+- 로그 레벨을 `DEBUG`로 올리면 프레임 전송 내역을 자세히 확인할 수 있습니다.
+
+## 윈도우용 실행 파일 만들기
+
+Python이 설치되어 있지 않은 PC에서 사용하거나 배포가 필요하다면
+[PyInstaller](https://pyinstaller.org/)를 이용해 실행 파일(`.exe`)로 묶을 수 있습니다.
+
+1. PyInstaller 설치
+
+   ```powershell
+   pip install pyinstaller
+   ```
+
+2. 저장소 루트에서 제공하는 빌드 스크립트를 실행합니다.
+
+   ```powershell
+   python scripts/build_executable.py
+   ```
+
+   Windows에서는 `dist\can_udp_bridge.exe`가 생성됩니다. 다른 운영체제에서도 같은
+   명령을 사용할 수 있으며, 해당 플랫폼용 실행 파일이 만들어집니다.
+
+3. 실행 파일과 함께 사용할 구성 파일을 같은 폴더에 배치합니다.
+
+   ```powershell
+   copy config\example_config.json can_config.json
+   ```
+
+   생성된 `can_udp_bridge.exe`를 다음과 같이 실행할 수 있습니다.
+
+   ```powershell
+   .\dist\can_udp_bridge.exe --config can_config.json --log-level INFO
+   ```
+
+   `--config`에 전달하는 경로는 실행 파일이 위치한 폴더 기준 상대 경로이거나
+   절대 경로를 사용할 수 있습니다.

--- a/config/example_config.json
+++ b/config/example_config.json
@@ -1,0 +1,37 @@
+{
+  "can": {
+    "interface": "socketcan",
+    "channel": "can0",
+    "bitrate": 500000,
+    "receive_own_messages": false,
+    "filters": [
+      { "can_id": 256, "can_mask": 2047, "extended": false }
+    ]
+  },
+  "udp": {
+    "host": "192.168.0.100",
+    "port": 4000
+  },
+  "include_raw_frame": true,
+  "signals": [
+    {
+      "name": "vehicle_speed",
+      "can_id": "0x100",
+      "start_bit": 0,
+      "length": 16,
+      "byte_order": "big",
+      "scale": 0.01,
+      "offset": 0.0
+    },
+    {
+      "name": "steering_angle",
+      "can_id": "0x101",
+      "start_bit": 16,
+      "length": 16,
+      "byte_order": "little",
+      "scale": 0.1,
+      "offset": -780.0,
+      "signed": true
+    }
+  ]
+}

--- a/scripts/build_executable.py
+++ b/scripts/build_executable.py
@@ -1,0 +1,50 @@
+"""Helper script to bundle can_udp_bridge.py into a standalone executable."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def _require_pyinstaller() -> None:
+    try:
+        import PyInstaller.__main__  # type: ignore[attr-defined]
+    except ModuleNotFoundError as exc:  # pragma: no cover - runtime dependency check
+        raise SystemExit(
+            "PyInstaller is required to build the executable. Install it with 'pip install pyinstaller'."
+        ) from exc
+
+
+def build() -> None:
+    _require_pyinstaller()
+
+    import PyInstaller.__main__  # type: ignore[attr-defined]
+
+    project_root = Path(__file__).resolve().parents[1]
+    entry_script = project_root / "src" / "can_udp_bridge.py"
+
+    if not entry_script.exists():  # pragma: no cover - sanity check
+        raise SystemExit(f"Entry script not found: {entry_script}")
+
+    add_data_sep = ";" if os.name == "nt" else ":"
+    config_example = project_root / "config" / "example_config.json"
+    add_data_arg = f"{config_example}{add_data_sep}config"
+
+    PyInstaller.__main__.run(
+        [
+            str(entry_script),
+            "--onefile",
+            "--name",
+            "can_udp_bridge",
+            "--add-data",
+            add_data_arg,
+        ]
+    )
+
+
+def main() -> None:
+    build()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/can_udp_bridge.py
+++ b/src/can_udp_bridge.py
@@ -1,0 +1,251 @@
+"""CAN to UDP bridge for TOSUN CAN USB devices.
+
+This script listens to frames on a CAN bus and forwards configured signals
+as JSON payloads over UDP.  It is designed for use with TOSUN CAN USB
+interfaces that expose a SocketCAN or compatible interface via python-can.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import socket
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+try:
+    import can
+except ImportError as exc:  # pragma: no cover - informative error
+    raise SystemExit(
+        "python-can is required to run this script. Install it with 'pip install python-can'."
+    ) from exc
+
+
+@dataclass(frozen=True)
+class SignalConfig:
+    """Configuration describing how to extract a signal from a CAN frame."""
+
+    name: str
+    can_id: int
+    start_bit: int
+    length: int
+    byte_order: str = "little"
+    signed: bool = False
+    scale: float = 1.0
+    offset: float = 0.0
+
+    def __post_init__(self) -> None:  # type: ignore[override]
+        if self.length <= 0:
+            raise ValueError(f"Signal '{self.name}' length must be positive")
+        if self.start_bit < 0:
+            raise ValueError(f"Signal '{self.name}' start_bit cannot be negative")
+        if self.byte_order not in {"little", "big"}:
+            raise ValueError(
+                f"Signal '{self.name}' byte_order must be either 'little' or 'big', got {self.byte_order!r}"
+            )
+
+
+def _load_config(path: Path) -> dict:
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except FileNotFoundError as exc:  # pragma: no cover - configuration error
+        raise SystemExit(f"Configuration file not found: {path}") from exc
+    except json.JSONDecodeError as exc:  # pragma: no cover - configuration error
+        raise SystemExit(f"Failed to parse configuration file {path}: {exc}") from exc
+
+
+def _build_signal_map(signal_configs: Iterable[SignalConfig]) -> Dict[int, List[SignalConfig]]:
+    signal_map: Dict[int, List[SignalConfig]] = {}
+    for cfg in signal_configs:
+        signal_map.setdefault(cfg.can_id, []).append(cfg)
+    return signal_map
+
+
+def _extract_signal(data: bytes, cfg: SignalConfig) -> float:
+    total_bits = len(data) * 8
+    if cfg.start_bit + cfg.length > total_bits:
+        raise ValueError(
+            f"Signal '{cfg.name}' (start_bit={cfg.start_bit}, length={cfg.length}) exceeds frame size ({total_bits} bits)"
+        )
+
+    mask = (1 << cfg.length) - 1
+    if cfg.byte_order == "big":
+        value = int.from_bytes(data, byteorder="big", signed=False)
+        shift = total_bits - cfg.start_bit - cfg.length
+    else:
+        value = int.from_bytes(data, byteorder="little", signed=False)
+        shift = cfg.start_bit
+
+    raw = (value >> shift) & mask
+    if cfg.signed and cfg.length > 0 and (raw & (1 << (cfg.length - 1))):
+        raw -= 1 << cfg.length
+
+    scaled = raw * cfg.scale + cfg.offset
+    return scaled
+
+
+def _create_bus(can_config: dict) -> can.Bus:
+    bus_kwargs = {
+        key: value
+        for key, value in can_config.items()
+        if key
+        not in {
+            "filters",
+        }
+    }
+    try:
+        bus = can.Bus(**bus_kwargs)
+    except TypeError as exc:  # pragma: no cover - configuration error
+        raise SystemExit(f"Invalid CAN configuration: {exc}") from exc
+
+    filters = can_config.get("filters")
+    if filters:
+        try:
+            bus.set_filters(filters)
+        except can.CanError as exc:  # pragma: no cover - runtime error
+            raise SystemExit(f"Failed to set CAN filters: {exc}") from exc
+
+    return bus
+
+
+def _send_udp(sock: socket.socket, destination: Tuple[str, int], payload: dict) -> None:
+    data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    sock.sendto(data, destination)
+
+
+def _process_frame(
+    message: can.Message,
+    signal_map: Dict[int, List[SignalConfig]],
+    sock: socket.socket,
+    destination: Tuple[str, int],
+    include_raw_frame: bool,
+) -> None:
+    configs = signal_map.get(message.arbitration_id)
+    if not configs:
+        return
+
+    extracted = {}
+    for cfg in configs:
+        try:
+            value = _extract_signal(message.data, cfg)
+        except ValueError as exc:
+            logging.warning("Failed to extract signal %s: %s", cfg.name, exc)
+            continue
+        extracted[cfg.name] = value
+
+    if not extracted:
+        return
+
+    payload = {
+        "timestamp": message.timestamp,
+        "can_id": message.arbitration_id,
+        "extended": message.is_extended_id,
+        "signals": extracted,
+    }
+
+    if include_raw_frame:
+        payload["raw_data"] = message.data.hex()
+
+    _send_udp(sock, destination, payload)
+    logging.debug("Forwarded CAN ID 0x%X with signals %s", message.arbitration_id, extracted)
+
+
+def _parse_signal_configs(config: dict) -> List[SignalConfig]:
+    signals_cfg = config.get("signals", [])
+    signal_configs: List[SignalConfig] = []
+    for entry in signals_cfg:
+        try:
+            signal_configs.append(
+                SignalConfig(
+                    name=entry["name"],
+                    can_id=int(entry["can_id"], 0)
+                    if isinstance(entry["can_id"], str)
+                    else int(entry["can_id"]),
+                    start_bit=int(entry.get("start_bit", 0)),
+                    length=int(entry["length"]),
+                    byte_order=entry.get("byte_order", "little"),
+                    signed=bool(entry.get("signed", False)),
+                    scale=float(entry.get("scale", 1.0)),
+                    offset=float(entry.get("offset", 0.0)),
+                )
+            )
+        except KeyError as exc:  # pragma: no cover - configuration error
+            raise SystemExit(f"Signal configuration is missing required field: {exc}") from exc
+        except ValueError as exc:  # pragma: no cover - configuration error
+            raise SystemExit(f"Invalid signal configuration: {exc}") from exc
+    return signal_configs
+
+
+def _setup_logging(level: str) -> None:
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
+
+def run(config_path: Path) -> None:
+    config = _load_config(config_path)
+
+    can_config = config.get("can")
+    if not isinstance(can_config, dict):  # pragma: no cover - configuration error
+        raise SystemExit("Configuration must define a 'can' section")
+
+    udp_config = config.get("udp")
+    if not isinstance(udp_config, dict):  # pragma: no cover - configuration error
+        raise SystemExit("Configuration must define a 'udp' section")
+
+    include_raw_frame = bool(config.get("include_raw_frame", False))
+
+    signal_map = _build_signal_map(_parse_signal_configs(config))
+    if not signal_map:
+        logging.warning("No signals configured; frames will not be forwarded")
+
+    destination = (udp_config.get("host", "127.0.0.1"), int(udp_config.get("port", 5000)))
+
+    with _create_bus(can_config) as bus, socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        logging.info(
+            "Forwarding CAN frames to UDP %s:%s", destination[0], destination[1]
+        )
+        while True:
+            try:
+                message = bus.recv(timeout=1.0)
+            except can.CanError as exc:  # pragma: no cover - runtime error
+                logging.error("CAN bus error: %s", exc)
+                time.sleep(1.0)
+                continue
+
+            if message is None:
+                continue
+
+            _process_frame(message, signal_map, sock, destination, include_raw_frame)
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Bridge CAN frames to UDP packets")
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("config/example_config.json"),
+        help="Path to the configuration JSON file",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Logging level (e.g. DEBUG, INFO, WARNING)",
+    )
+    args = parser.parse_args(argv)
+
+    _setup_logging(args.log_level)
+
+    try:
+        run(args.config)
+    except KeyboardInterrupt:
+        logging.info("Interrupted by user; shutting down")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a helper script that wraps PyInstaller to build a single-file CAN-to-UDP executable
- document the steps for packaging and running the generated Windows `.exe`

## Testing
- python -m compileall src/can_udp_bridge.py scripts/build_executable.py

------
https://chatgpt.com/codex/tasks/task_e_68df920a49508329bce2984b581ad65e